### PR TITLE
No negative numbers on workers list pagination

### DIFF
--- a/asyncmq/contrib/dashboard/controllers/workers.py
+++ b/asyncmq/contrib/dashboard/controllers/workers.py
@@ -39,8 +39,8 @@ class WorkerController(DashboardMixin, TemplateController):
         size = max(1, int(qs.get("size", 20)))
 
         total = len(all_workers)
-        total_pages = math.ceil(total / size) if size else 1
-        page = min(page, total_pages)
+        total_pages = math.ceil(total / size) if total > 0 and size else 1
+        page = min(page, total_pages) if total_pages > 0 else 1
 
         start = (page - 1) * size
         end = start + size

--- a/asyncmq/contrib/dashboard/templates/workers/workers.html
+++ b/asyncmq/contrib/dashboard/templates/workers/workers.html
@@ -71,6 +71,7 @@
   <!-- Pagination & Summary -->
   <div class="mt-6 flex flex-col sm:flex-row sm:items-center sm:justify-between">
     <p class="text-sm text-gray-700 mb-4 sm:mb-0">
+      {% if total > 0 %}
       Showing
       <span class="font-medium">{{ (page - 1) * size + 1 }}</span>
       to
@@ -78,6 +79,9 @@
       of
       <span class="font-medium">{{ total }}</span>
       results
+      {% else %}
+      No results found
+      {% endif %}
     </p>
     <nav class="inline-flex -space-x-px">
       {% if page and page > 1 %}


### PR DESCRIPTION
We had this before:

 "Showing -19 to -20 of 0 results"

### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
