### PR TITLE
Render urls with mount prefix under FastAPI

### DIFF
--- a/asyncmq/contrib/dashboard/mixins.py
+++ b/asyncmq/contrib/dashboard/mixins.py
@@ -5,6 +5,7 @@ from lilya.requests import Request
 from asyncmq.conf import monkay
 from asyncmq.contrib.dashboard.engine import templates
 from asyncmq.contrib.dashboard.messages import get_messages
+from asyncmq.core.utils.dashboard import get_effective_prefix
 
 
 class DashboardMixin:
@@ -12,12 +13,15 @@ class DashboardMixin:
 
     async def get_context_data(self, request: Request, **kwargs: Any) -> dict:
         context = {}
+
+        effective_prefix = get_effective_prefix(request)
+
         context.update(
             {
                 "title": monkay.settings.dashboard_config.title,
                 "header_text": monkay.settings.dashboard_config.header_title,
                 "favicon": monkay.settings.dashboard_config.favicon,
-                "url_prefix": monkay.settings.dashboard_config.dashboard_url_prefix,
+                "url_prefix": effective_prefix,
                 "sidebar_bg_colour": monkay.settings.dashboard_config.sidebar_bg_colour,
                 "messages": get_messages(request),
             }

--- a/asyncmq/core/utils/dashboard.py
+++ b/asyncmq/core/utils/dashboard.py
@@ -3,6 +3,9 @@ from dataclasses import dataclass
 
 from lilya.middleware import DefineMiddleware
 from lilya.middleware.sessions import SessionMiddleware
+from lilya.requests import Request
+
+from asyncmq.conf import monkay
 
 
 @dataclass
@@ -14,3 +17,26 @@ class DashboardConfig:
     dashboard_url_prefix: str = "/admin"
     sidebar_bg_colour: str = "#CBDC38"
     session_middleware: DefineMiddleware = DefineMiddleware(SessionMiddleware, secret_key=secrets.token_hex(32))
+
+
+def get_effective_prefix(request: Request) -> str:
+    """Compute the effective base URL prefix for the dashboard.
+
+    Combines the ASGI mount root_path (if any) with the configured dashboard
+    URL prefix. Ensures a clean result without double slashes and with no
+    trailing slash, except when the result is exactly "/".
+    """
+    configured_prefix = monkay.settings.dashboard_config.dashboard_url_prefix or ""
+    mount_prefix = (getattr(request, "scope", None) or {}).get("root_path", "") or ""
+
+    # If the mount prefix already includes the configured prefix, don't double it.
+    if configured_prefix and (
+        mount_prefix.endswith(configured_prefix)
+        or f"{mount_prefix}/".endswith(f"{configured_prefix}/")
+    ):
+        base = mount_prefix
+    else:
+        base = f"{mount_prefix}{configured_prefix or '/'}"
+
+    # Avoid trailing slash unless it's the root
+    return base if base == "/" else base.rstrip("/")

--- a/tests/dashboard/test_fastapi.py
+++ b/tests/dashboard/test_fastapi.py
@@ -34,3 +34,36 @@ def test_home_page(client):
     response = client.get(("fastapi/admin"))
     assert response.status_code == 200
     assert config.title.encode() in response.content
+
+
+def test_sidebar_links_include_mount_prefix(client):
+    settings.backend = RedisBackend()
+
+    # Load the dashboard home page
+    resp = client.get("/fastapi/admin")
+    assert resp.status_code == 200
+
+    html = resp.text
+
+    # Expected links with mount prefix
+    assert 'href="/fastapi/admin"' in html
+    assert 'href="/fastapi/admin/queues"' in html
+    assert 'href="/fastapi/admin/metrics"' in html
+    assert 'href="/fastapi/admin/workers"' in html
+
+    # Ensure incorrect, unmounted links are NOT present
+    assert 'href="/admin"' not in html
+    assert 'href="/admin/queues"' not in html
+    assert 'href="/admin/metrics"' not in html
+    assert 'href="/admin/workers"' not in html
+
+
+def test_extract_mount_path_prefers_root_path_when_available():
+    scope = {"type": "http", "path": "/something/else", "root_path": "/fastapi"}
+    # Expected behavior: if root_path is available, it should be returned as the mount path
+    assert dashboard._extract_mount_path(scope) == "/fastapi"
+
+
+def test_extract_mount_path_with_admin_in_path_still_uses_root_path():
+    scope = {"type": "http", "path": "/fastapi/admin", "root_path": "/fastapi"}
+    assert dashboard._extract_mount_path(scope) == "/fastapi"


### PR DESCRIPTION
When mounting the dashboard under fastapi, links would not work because they did not respect the mount prefix. Now they do.

### Checklist

- [x] The code has 100% test coverage.
- [x] The documentation was properly created or updated (if applicable) following the correct guidelines and appropriate language.
- [x] I branched out from the latest main or is a sub-branch.

### Summary or description
